### PR TITLE
feat: add fast point-to-scalar multiplication via ecrecover

### DIFF
--- a/examples/secp256k1/Secp256k1.sol
+++ b/examples/secp256k1/Secp256k1.sol
@@ -59,13 +59,15 @@ contract Secp256k1Example is Script {
         */
 
         // Derive common constructs.
-        address addr = pk.toAddress();
+        address addr1 = sk.toAddress();
+        address addr2 = pk.toAddress();
+        assert(addr1 == addr2);
         /*
         bytes32 digest = pk.toHash();
         uint yParity = pk.yParity();
         */
         console.log("Derived address:");
-        console.log(addr);
+        console.log(addr1);
         console.log("");
 
         // Serialization.

--- a/src/onchain/secp256k1/Secp256k1.sol
+++ b/src/onchain/secp256k1/Secp256k1.sol
@@ -144,6 +144,9 @@ library Secp256k1 {
 
     /// @dev Returns the address of secret key `sk`.
     ///
+    /// @dev Note that this function is substantially cheaper than computing
+    ///      `sk`'s public key and deriving it's address manually.
+    ///
     /// @dev Reverts if:
     ///        Secret key invalid
     function toAddress(SecretKey sk) internal pure returns (address) {
@@ -151,9 +154,7 @@ library Secp256k1 {
             revert("SecretKeyInvalid()");
         }
 
-        // Use fastMul to compute pk = [sk]G.
-        Point memory g = Secp256k1Arithmetic.G();
-        return g.fastMul(sk.asUint());
+        return Secp256k1Arithmetic.G().mulToAddress(sk.asUint());
     }
 
     //--------------------------------------------------------------------------

--- a/src/onchain/secp256k1/Secp256k1.sol
+++ b/src/onchain/secp256k1/Secp256k1.sol
@@ -142,6 +142,20 @@ library Secp256k1 {
         return SecretKey.unwrap(sk);
     }
 
+    /// @dev Returns the address of secret key `sk`.
+    ///
+    /// @dev Reverts if:
+    ///        Secret key invalid
+    function toAddress(SecretKey sk) internal pure returns (address) {
+        if (!sk.isValid()) {
+            revert("SecretKeyInvalid()");
+        }
+
+        // Use fastMul to compute pk = [sk]G.
+        Point memory g = Secp256k1Arithmetic.G();
+        return g.fastMul(sk.asUint());
+    }
+
     //--------------------------------------------------------------------------
     // Public Key
 

--- a/src/onchain/secp256k1/Secp256k1Arithmetic.sol
+++ b/src/onchain/secp256k1/Secp256k1Arithmetic.sol
@@ -308,6 +308,31 @@ library Secp256k1Arithmetic {
         return result;
     }
 
+    /// @dev Returns the product of point `point` and scalar `scalar`
+    ///      as an Ethereum address.
+    ///
+    ///      See [SEC-1 v2] section 4.1.6 "Public Key Recovery Operation".
+    function fastMul(Point memory point, uint scalar)
+        internal
+        pure
+        returns (address)
+    {
+        if (scalar >= Q) {
+            revert("ScalarMustBeFelt()");
+        }
+
+        if (scalar == 0 || point.isIdentity()) {
+            // This is the same as `Secp256k1Arithmetic.Identity().intoPublicKey().toAddress()`.
+            return 0x2dCC482901728b6df477f4fB2F192733A005d396;
+        }
+
+        uint8 v = uint8(point.yParity()) + 27;
+        uint r = point.x;
+        uint s = mulmod(r, scalar, Q);
+
+        return ecrecover(0, v, bytes32(r), bytes32(s));
+    }
+
     // TODO: Provide verifyMul(point,scalar,want) using ecrecover?
 
     //--------------------------------------------------------------------------

--- a/src/onchain/secp256k1/Secp256k1Arithmetic.sol
+++ b/src/onchain/secp256k1/Secp256k1Arithmetic.sol
@@ -48,6 +48,7 @@ struct ProjectivePoint {
  *      - [Yellow Paper]: https://github.com/ethereum/yellowpaper
  *      - [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060.pdf
  *      - [Dubois 2023]: https://eprint.iacr.org/2023/939.pdf
+ *      - [Vitalik 2018]: https://ethresear.ch/t/you-can-kinda-abuse-ecrecover-to-do-ecmul-in-secp256k1-today/2384
  *
  * @author verklegarden
  * @custom:repository github.com/verklegarden/crysol
@@ -71,6 +72,10 @@ library Secp256k1Arithmetic {
     /// @dev Note that the square root of an secp256k1 field element x can be
     ///      computed via x^{SQUARE_ROOT_EXPONENT} (mod p).
     uint private constant SQUARE_ROOT_EXPONENT = (P + 1) / 4;
+
+    /// @dev Used as substitute for `Identity().intoPublicKey().toAddress()`.
+    address private constant IDENTITY_ADDRESS =
+        0x2dCC482901728b6df477f4fB2F192733A005d396;
 
     //--------------------------------------------------------------------------
     // Secp256k1 Constants
@@ -308,11 +313,13 @@ library Secp256k1Arithmetic {
         return result;
     }
 
-    /// @dev Returns the product of point `point` and scalar `scalar`
-    ///      as an Ethereum address.
+    /// @dev Returns the product of point `point` and scalar `scalar` as
+    ///      address.
     ///
-    ///      See [SEC-1 v2] section 4.1.6 "Public Key Recovery Operation".
-    function fastMul(Point memory point, uint scalar)
+    /// @dev Note that this function is substantially cheaper than
+    ///      `mul(ProjectivePoint,uint)(ProjectivePoint)` with the caveat that
+    ///      only the point's address is returned instead of the point itself.
+    function mulToAddress(Point memory point, uint scalar)
         internal
         pure
         returns (address)
@@ -322,18 +329,27 @@ library Secp256k1Arithmetic {
         }
 
         if (scalar == 0 || point.isIdentity()) {
-            // This is the same as `Secp256k1Arithmetic.Identity().intoPublicKey().toAddress()`.
-            return 0x2dCC482901728b6df477f4fB2F192733A005d396;
+            return IDENTITY_ADDRESS;
         }
 
-        uint8 v = uint8(point.yParity()) + 27;
+        // Note that ecrecover can be abused to perform an elliptic curve
+        // multiplication with the caveat that the point's address is returned
+        // instead of the point itself.
+        //
+        // For further details, see [Vitalik 2018] and [SEC-1 v2] section 4.1.6
+        // "Public Key Recovery Operation".
+
+        uint8 v;
+        // Unchecked because point.yParity() ∊ {0, 1} which cannot overflow by
+        // adding 27.
+        unchecked {
+            v = uint8(point.yParity() + 27);
+        }
         uint r = point.x;
         uint s = mulmod(r, scalar, Q);
 
         return ecrecover(0, v, bytes32(r), bytes32(s));
     }
-
-    // TODO: Provide verifyMul(point,scalar,want) using ecrecover?
 
     //--------------------------------------------------------------------------
     // Type Conversions
@@ -389,6 +405,7 @@ library Secp256k1Arithmetic {
 
         // Return as Point(point.x, point.y).
         // Note that from this moment, point.z is dirty memory!
+        // TODO: Clean dirty memory.
         assembly ("memory-safe") {
             p := point
         }

--- a/test/onchain/secp256k1/Secp256k1.t.sol
+++ b/test/onchain/secp256k1/Secp256k1.t.sol
@@ -100,8 +100,33 @@ contract Secp256k1Test is Test {
 
     // -- asUint
 
-    function testFuzz_SecertKey_asUint(uint seed) public {
+    function testFuzz_SecretKey_asUint(uint seed) public {
         assertEq(seed, wrapper.asUint(SecretKey.wrap(seed)));
+    }
+
+    function testFuzz_SecretKey_toAddress(SecretKey sk) public {
+        vm.assume(sk.isValid());
+
+        address got = wrapper.toAddress(sk);
+        address want = vm.addr(sk.asUint());
+
+        assertEq(got, want);
+    }
+
+    function test_SecretKey_toAddress_RevertsIf_SecretKeyInvalid_SecretKeyZero()
+        public
+    {
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.toAddress(SecretKey.wrap(0));
+    }
+
+    function testFuzz_SecretKey_toAddress_RevertsIf_SecretKeyInvalid_SecretKeyGreaterOrEqualToQ(
+        uint seed
+    ) public {
+        uint scalar = _bound(seed, Secp256k1.Q, type(uint).max);
+
+        vm.expectRevert("SecretKeyInvalid()");
+        wrapper.toAddress(SecretKey.wrap(scalar));
     }
 
     //--------------------------------------------------------------------------
@@ -316,6 +341,10 @@ contract Secp256k1Wrapper {
 
     function asUint(SecretKey sk) public pure returns (uint) {
         return sk.asUint();
+    }
+
+    function toAddress(SecretKey sk) public pure returns (address) {
+        return sk.toAddress();
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #18

Explanation of how it works:
- `ecrecover(e, v, r, s)` works according to the formula $Q = r^{-1} \( sR - eG \)$ from [SEC-1 v2](https://www.secg.org/sec1-v2.pdf) section 4.1.6 "Public Key Recovery Operation"
- the formula has some limitations: $v \in \[ 27, 28 \], r \ne 0, s \ne 0$
- to calculate $scalar \cdot Point$ need to substitute the following values:
  $e = 0, v = PointYParity + 27, r = PointX, s = r \cdot scalar$
- so the formula will look like this after substitution:
  $Q = r^{-1} sR = r^{-1} \cdot r \cdot scalar \cdot R = \cancel{r^{-1}} \cdot \cancel{r} \cdot scalar \cdot R = scalar \cdot R$
- point $R(x, y)$ has coordinates $(r, y)$, where $y$ is calculated from $x$ (coordinate compression) and $v$ (even/odd $y$ is specified)
